### PR TITLE
Feature/gameplay/size-relative-health

### DIFF
--- a/Assets/Presets/Gameplay/Settings/st_player_settings.tres
+++ b/Assets/Presets/Gameplay/Settings/st_player_settings.tres
@@ -8,7 +8,9 @@
 script = ExtResource("1_c8fa2")
 speed = 300.0
 jump_height_in_px = 50.0
-max_health = 3
+small_size_max_health = 2
+regular_size_max_health = 6
+large_size_max_health = 12
 default_zoom = 4.0
 can_attack = true
 attack_damage = 1.0

--- a/Scripts/Gameplay/Interactables/health_node.gd
+++ b/Scripts/Gameplay/Interactables/health_node.gd
@@ -26,6 +26,8 @@ func set_max_health(target_max_health : int) -> void:
 	if m_current_health <= 0:
 		m_current_health = m_max_health
 
+func set_current_health(new_health: int) -> void:
+	m_current_health = new_health
 
 func apply_damage(incoming_damage : float) -> void:
 	if m_current_health <= 0:

--- a/Scripts/Gameplay/Player/player_settings.gd
+++ b/Scripts/Gameplay/Player/player_settings.gd
@@ -4,7 +4,9 @@ extends Resource
 @export_group("Default")
 @export var speed : float = 300
 @export var jump_height_in_px : float = 10.0
-@export var max_health : int = 3
+@export var small_size_max_health : int = 2
+@export var regular_size_max_health : int = 6
+@export var large_size_max_health : int = 12
 @export var default_zoom : float = 8
 @export_group("Attack")
 @export var can_attack : bool = true


### PR DESCRIPTION
The player's health status now scales with size. 

for example: a player with 50% max health will still have 50% when it shifts sizes. 
